### PR TITLE
Load wp_get_current_user() if it does not exist

### DIFF
--- a/public/classes/Model/ProcessLog.php
+++ b/public/classes/Model/ProcessLog.php
@@ -56,7 +56,10 @@ class ProcessLog extends DatabaseItem {
 
 
 		$this->created = $this->getTimestamp();
-
+		
+		if ( ! function_exists( 'wp_get_current_user' ) ) {
+			require_once ABSPATH . WPINC . '/pluggable.php';
+		}
 		$user = wp_get_current_user();
 		if ( $user instanceof \WP_User ) {
 			$this->active_user = $user->ID;


### PR DESCRIPTION
Some plugin like [Yoast SEO](https://github.com/Yoast/wordpress-seo/blob/0742e9b6ba4c0d6ae9d65223267a106b92a6a4a1/src/config/migration-status.php#L174) change the options once their plugin has loaded and do not wait till `pluggable.php` is loaded.

- [Loading Plugins in WP](https://github.com/WordPress/WordPress/blob/033c742a4ea67698ef465f0b6a7fdcc84e03868d/wp-settings.php#L406)
- [Requiring `pluggable.php`](https://github.com/WordPress/WordPress/blob/033c742a4ea67698ef465f0b6a7fdcc84e03868d/wp-settings.php#L423)

This can be seen by looking at the traceback.
```
require_once('wp-load.php'),
require_once('/var/www/html/wordpress/wp-config.php'),
require_once('wp-settings.php'), include_once('/plugins/wordpress-seo/wp-seo.php'),
require_once('/plugins/wordpress-seo/wp-seo-main.php'),
WPSEO_Addon_Manager->register_hooks,
WPSEO_Addon_Manager->get_installed_addons,
array_filter, WPSEO_Addon_Manager->is_yoast_addon,
WPSEO_Addon_Manager->get_slug_by_plugin_file,
YoastSEO,
Yoast\WP\Lib\Abstract_Main->load, Yoast\WP\SEO\Loader->load, Yoast\WP\SEO\Loader->load_initializers, Yoast\WP\SEO\Initializers\Migration_Runner->initialize,
Yoast\WP\SEO\Initializers\Migration_Runner->run_free_migrations,
Yoast\WP\SEO\Initializers\Migration_Runner->run_migrations,
Yoast\WP\SEO\Config\Migration_Status->lock_migration,
Yoast\WP\SEO\Config\Migration_Status->set_migration_status,
update_option, do_action('updated_option'), WP_Hook->do_action,
WP_Hook->apply_filters, Palasthotel\ProcessLog\Watcher\OptionsWatcher->updated, Palasthotel\ProcessLog\Model\ProcessLog::build,
Palasthotel\ProcessLog\Model\ProcessLog->__construct
```

This thus causes a PHP fatal error as `wp_get_current_user()` is defined in `pluggable.php`

```
PHP Fatal error:  Uncaught Error: Call to undefined function Palasthotel\ProcessLog\Model\wp_get_current_user() in /var/www/html/wordpress/content/plugins/process-log/classes/Model/ProcessLog.php:62
Stack trace:
#0 /var/www/html/wordpress/content/plugins/process-log/classes/Model/ProcessLog.php(46): Palasthotel\ProcessLog\Model\ProcessLog->__construct()
#1 /var/www/html/wordpress/content/plugins/process-log/classes/Watcher/OptionsWatcher.php(56): Palasthotel\ProcessLog\Model\ProcessLog::build()
#2 /var/www/html/wordpress/wp/wp-includes/class-wp-hook.php(292): Palasthotel\ProcessLog\Watcher\OptionsWatcher->updated('yoast_migration...', Array, Array)
#3 /var/www/html/wordpress/wp/wp-includes/class-wp-hook.php(316): WP_Hook->apply_filters('', Array)
#4 /var/www/html/wordpress/wp/wp-includes/plugin.php(484): WP_Hook->do_action(Array)
#5 /var/www/html/wordpress/wp/wp-includes/option.php(486): do_action('updated_option', 'yoast_migration...', Array, Array)
#6 /var/www/html/wordpress/content/plugins/wordpress-seo/src/config/migration in /var/www/html/wordpress/content/plugins/process-log/classes/Model/ProcessLog.php on line 62
```